### PR TITLE
KeyguardSimPinView: don't send dummy request to get remaining pin

### DIFF
--- a/packages/Keyguard/src/com/android/keyguard/KeyguardSimPinView.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardSimPinView.java
@@ -325,6 +325,8 @@ public class KeyguardSimPinView extends KeyguardPinBasedInputView {
                         getPinPasswordErrorMessage(mRemainingAttempts, true),
                         true);
             return;
+        } else {
+            mSecurityMessageDisplay.setMessage(R.string.kg_sim_pin_instructions, true);
         }
 
         int count = TelephonyManager.getDefault().getSimCount();
@@ -343,19 +345,6 @@ public class KeyguardSimPinView extends KeyguardPinBasedInputView {
         }
         mSecurityMessageDisplay.setMessage(msg, true);
         mSimImageView.setImageTintList(ColorStateList.valueOf(color));
-
-        new CheckSimPin("", mSubId) {
-            void onSimCheckResponse(final int result, final int attemptsRemaining) {
-                Log.d(LOG_TAG, "onSimCheckResponse " + " dummy One result" + result +
-                        " attemptsRemaining=" + attemptsRemaining);
-                if (attemptsRemaining >= 0) {
-                    mRemainingAttempts = attemptsRemaining;
-                    mResult = result;
-                    mSecurityMessageDisplay.setMessage(
-                            getPinPasswordErrorMessage(attemptsRemaining, true), true);
-                }
-            }
-        }.start();
     }
 }
 


### PR DESCRIPTION
I'm not sure of the behavior on QCOM RILs, but on Broadcom RIL
(and probably other RILs), this will eat into the user's PIN
remaining tries. Given that the user is only given ~3 tries, this
is a very bad idea.

In addition, if onAttachedToWindow is called multiple times before
the RIL replies, this can completely delete the retry quota leading
straight to the PUK screen.

Change-Id: I339f1b6d79d543ae8930a7bb95acf823fd5ae20e